### PR TITLE
✨ Add rust-analyzer for Rust development 🦀

### DIFF
--- a/Scripts/custom_apps.lst
+++ b/Scripts/custom_apps.lst
@@ -20,6 +20,7 @@ antimicrox                                             # controller configurator
 xdg-desktop-portal-gtk                                 # xdg desktop portal using gtk
 mpv                                                    # audio player for anki
 ntfs-3g                                                # support for ntfs
+rust-analyzer                                          # analyzer for rust
 
 # Emoji selector and wtype also for glyph selector
 wtype


### PR DESCRIPTION
Add rust-analyzer to custom_apps.lst to improve Rust project analysis.